### PR TITLE
Design: 텍스트 인풋 제작

### DIFF
--- a/src/components/input/Checkbox/index.tsx
+++ b/src/components/input/Checkbox/index.tsx
@@ -1,0 +1,5 @@
+const Checkbox = () => {
+  return <div>Checkbox</div>;
+};
+
+export default Checkbox;

--- a/src/components/input/TextInput/index.tsx
+++ b/src/components/input/TextInput/index.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps, ReactNode } from "react";
+import { IoCheckmark } from "react-icons/io5";
 import * as S from "./styles";
 
 type Picked = "onChange" | "placeholder" | "value" | "type";
@@ -25,7 +26,8 @@ const TextInput = ({
       <S.InputWrapper>
         <S.Input required className={`${errorMessage ? "error" : ""}`} {...props} />
         {variant === "smooth" && <S.Label className="move">{label}</S.Label>}
-        {isSuccess && <S.RightElement>{rightElement}</S.RightElement>}
+        {rightElement && <S.RightElement>{rightElement}</S.RightElement>}
+        {isSuccess && <S.RightElement>{IoCheckmark}</S.RightElement>}
       </S.InputWrapper>
       {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
     </>

--- a/src/components/input/TextInput/index.tsx
+++ b/src/components/input/TextInput/index.tsx
@@ -10,11 +10,20 @@ interface InputProps extends Pick<ComponentProps<"input">, Picked> {
   errorMessage?: string;
   isSuccess?: boolean;
   rightElement?: ReactNode;
+  onRightElementClick?: VoidFunction;
 }
 
 const TextInput = forwardRef<HTMLInputElement, InputProps>(
   (
-    { variant = "move", errorMessage, isSuccess = false, label, rightElement = null, ...props },
+    {
+      variant = "move",
+      errorMessage,
+      isSuccess = false,
+      label,
+      rightElement = null,
+      onRightElementClick,
+      ...props
+    },
     ref
   ) => {
     return (
@@ -23,7 +32,11 @@ const TextInput = forwardRef<HTMLInputElement, InputProps>(
         <S.InputWrapper>
           <S.Input ref={ref} required className={`${errorMessage ? "error" : ""}`} {...props} />
           {variant === "move" && <S.Label className="move">{label}</S.Label>}
-          {rightElement && <S.RightElement>{rightElement}</S.RightElement>}
+          {rightElement && (
+            <S.RightElement {...(onRightElementClick && { onClick: onRightElementClick })}>
+              {rightElement}
+            </S.RightElement>
+          )}
           {isSuccess && <S.RightElement>{IoCheckmark}</S.RightElement>}
         </S.InputWrapper>
         {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}

--- a/src/components/input/TextInput/index.tsx
+++ b/src/components/input/TextInput/index.tsx
@@ -1,0 +1,35 @@
+import { ComponentProps, ReactNode } from "react";
+import * as S from "./styles";
+
+type Picked = "onChange" | "placeholder" | "value" | "type";
+
+interface InputProps extends Pick<ComponentProps<"input">, Picked> {
+  variant?: "static" | "smooth";
+  label?: string;
+  errorMessage?: string;
+  isSuccess?: boolean;
+  rightElement?: ReactNode;
+}
+
+const TextInput = ({
+  variant = "smooth",
+  errorMessage,
+  isSuccess = false,
+  label,
+  rightElement = null,
+  ...props
+}: InputProps) => {
+  return (
+    <>
+      {variant === "static" && <S.Label>{label}</S.Label>}
+      <S.InputWrapper>
+        <S.Input required className={`${errorMessage ? "error" : ""}`} {...props} />
+        {variant === "smooth" && <S.Label className="move">{label}</S.Label>}
+        {isSuccess && <S.RightElement>{rightElement}</S.RightElement>}
+      </S.InputWrapper>
+      {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
+    </>
+  );
+};
+
+export default TextInput;

--- a/src/components/input/TextInput/index.tsx
+++ b/src/components/input/TextInput/index.tsx
@@ -1,37 +1,35 @@
-import { ComponentProps, ReactNode } from "react";
+import { ComponentProps, ReactNode, forwardRef } from "react";
 import { IoCheckmark } from "react-icons/io5";
 import * as S from "./styles";
 
 type Picked = "onChange" | "placeholder" | "value" | "type";
 
 interface InputProps extends Pick<ComponentProps<"input">, Picked> {
-  variant?: "static" | "smooth";
+  variant?: "static" | "move";
   label?: string;
   errorMessage?: string;
   isSuccess?: boolean;
   rightElement?: ReactNode;
 }
 
-const TextInput = ({
-  variant = "smooth",
-  errorMessage,
-  isSuccess = false,
-  label,
-  rightElement = null,
-  ...props
-}: InputProps) => {
-  return (
-    <>
-      {variant === "static" && <S.Label>{label}</S.Label>}
-      <S.InputWrapper>
-        <S.Input required className={`${errorMessage ? "error" : ""}`} {...props} />
-        {variant === "smooth" && <S.Label className="move">{label}</S.Label>}
-        {rightElement && <S.RightElement>{rightElement}</S.RightElement>}
-        {isSuccess && <S.RightElement>{IoCheckmark}</S.RightElement>}
-      </S.InputWrapper>
-      {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
-    </>
-  );
-};
+const TextInput = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { variant = "move", errorMessage, isSuccess = false, label, rightElement = null, ...props },
+    ref
+  ) => {
+    return (
+      <>
+        {variant === "static" && <S.Label>{label}</S.Label>}
+        <S.InputWrapper>
+          <S.Input ref={ref} required className={`${errorMessage ? "error" : ""}`} {...props} />
+          {variant === "move" && <S.Label className="move">{label}</S.Label>}
+          {rightElement && <S.RightElement>{rightElement}</S.RightElement>}
+          {isSuccess && <S.RightElement>{IoCheckmark}</S.RightElement>}
+        </S.InputWrapper>
+        {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
+      </>
+    );
+  }
+);
 
 export default TextInput;

--- a/src/components/input/TextInput/styles.ts
+++ b/src/components/input/TextInput/styles.ts
@@ -50,7 +50,7 @@ export const Label = styled.label`
   }
 `;
 
-export const RightElement = styled.div`
+export const RightElement = styled.button`
   position: absolute;
 
   right: 0;

--- a/src/components/input/TextInput/styles.ts
+++ b/src/components/input/TextInput/styles.ts
@@ -1,0 +1,69 @@
+import styled from "@emotion/styled";
+
+export const InputWrapper = styled.div`
+  position: relative;
+
+  width: 100%;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+
+  border: none;
+  border-bottom: 1px solid ${(props) => props.theme.colors.gray[100]};
+  outline: none;
+
+  padding-block: 0.5rem;
+
+  color: ${(props) => props.theme.colors.gray[900]};
+  background-color: transparent;
+
+  font-family: "Pretendard";
+  font-size: 1rem;
+
+  &:focus + label.move,
+  &:valid + label.move {
+    top: -10px;
+    font-size: 0.75rem;
+  }
+
+  &.error {
+    border-bottom: 1px solid ${(props) => props.theme.colors.pink[200]};
+  }
+`;
+
+export const Label = styled.label`
+  position: relative;
+
+  white-space: nowrap;
+  opacity: 0.5;
+
+  &.move {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+
+    display: block;
+
+    transition: all 0.2s ease;
+  }
+`;
+
+export const RightElement = styled.div`
+  position: absolute;
+
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+
+  pointer-events: none;
+`;
+
+export const ErrorMessage = styled.p`
+  color: ${(props) => props.theme.colors.pink[200]};
+
+  font-size: 1rem;
+
+  margin-top: 0.25rem;
+`;

--- a/src/components/input/TextInput/styles.ts
+++ b/src/components/input/TextInput/styles.ts
@@ -18,7 +18,6 @@ export const Input = styled.input`
   color: ${(props) => props.theme.colors.gray[900]};
   background-color: transparent;
 
-  font-family: "Pretendard";
   font-size: 1rem;
 
   &:focus + label.move,

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -49,6 +49,9 @@ const globalStyles = css`
     background: transparent;
     cursor: pointer;
   }
+  input {
+    font-family: "Pretendard";
+  }
 
   @font-face {
     font-family: "Pretendard-Regular";


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
- 텍스트 인풋 제작

## 작업 내용 (변경 사항)
- value, onChange, placeholder, type 사용 가능합니다.
- static은 label만 있는 인풋, smooth는 placeholder가 함께 있는 인풋입니다.
- static 사용 시 placeholder는 사용하시면 안 됩니다. (겹침.. 더 나은 방법이 있을까요?)
- 에러메시지가 있으면 invalid인 것으로 간주합니다.

### 제작 가능한 인풋 종류
- [x] 아래 테두리
- [x] 아래 테두리, 레이블 (focus시 레이블이 위로 이동)
- [x] 아래 테두리, 레이블, 플레이스홀더 (정적인 인풋)
- [x] 아래 테두리, 레이블, 플레이스홀더, 우측 컨텐츠 (rightElement)
- [x] 아래 테두리, 레이블, 플레이스홀더, 체크 아이콘 (isSuccess)
- [x] 아래 테두리, 레이블, 플레이스홀더, 우측 컨텐츠, 에러 메시지
```
<TextInput
  variant="static"
  label="이메일"
  placeholder="이메일"
  rightElement={<IoCheckmark />}
  isSuccess={true}
  errorMessage="에러 메시지"
/>
<TextInput
  variant="smooth"
  label="이메일"
  rightElement={<IoCheckmark />}
  isSuccess={true}
  errorMessage="에러 메시지"
/>
```

## 스크린샷
<img width="801" alt="스크린샷 2024-01-04 오후 10 24 47" src="https://github.com/Yanabada/Yanabada_FE/assets/123650056/76b34fd6-2e89-4afb-8bfc-a416633ef02b">

## 리뷰 요청 사항
- 피그마 상에 있는 인풋의 형태는 대부분 구현했습니다. 혹시 누락된 부분이 있다면 말씀해주세요.
- 인풋을 합친다고 합쳤는데 솔직히 코드가 너무 지저분한 것 같습니다. 피드백 자유롭게 부탁드립니다!

close #10 
