### PR TITLE
Design: 마이페이지(G-6) 화면구현

### DIFF
--- a/src/components/card/ListCard/index.tsx
+++ b/src/components/card/ListCard/index.tsx
@@ -24,6 +24,7 @@ interface ListCardProps extends React.HTMLAttributes<HTMLDivElement> {
   timerText?: string;
   roomName: string;
   price: string;
+  badgeText: string;
 }
 
 const ListCard = ({
@@ -35,7 +36,8 @@ const ListCard = ({
   saleDate,
   timerText,
   roomName,
-  price
+  price,
+  badgeText
 }: ListCardProps) => {
   const getTimerIconColor = (cardType: ListCardProps["cardType"]) => {
     switch (cardType) {
@@ -71,7 +73,7 @@ const ListCard = ({
   return (
     <S.ListCardContainer width={width}>
       <S.TopWrapper>
-        <Badges badgeType={badgeType}>승인요청</Badges>
+        <Badges badgeType={badgeType}>{badgeText}</Badges>
         <S.TopRightWrapper>
           <S.TopRightText>{accommodationName}</S.TopRightText>
         </S.TopRightWrapper>

--- a/src/pages/myPage/components/Info/index.tsx
+++ b/src/pages/myPage/components/Info/index.tsx
@@ -19,76 +19,60 @@ interface PayInfoProps {
   charge?: string;
 }
 
-const Info = ({
-  divType,
-  width,
-  imageURL,
-  yanoljaPurchasePrice,
-  yanabadaPurchasePrice,
-  discountRate,
-  discountPrice,
-  from,
-  payMethod,
-  accommodationName,
-  roomName,
-  orderNumber,
-  buyer,
-  orderDate,
-  charge
-}: PayInfoProps) => {
+const Info = ({ ...props }: PayInfoProps) => {
   const textContent =
-    from === "sale"
+    props.from === "sale"
       ? "야나바다 판매가"
-      : from === "purchase" || from === "cancel"
+      : props.from === "purchase" || props.from === "cancel"
         ? "야나바다 구매가"
         : "";
 
-  switch (divType) {
+  switch (props.divType) {
     case "payInfo":
     case "payInfo-tall":
       return (
-        <S.InfoWrapper divType={divType} width={width}>
+        <S.InfoWrapper divType={props.divType} width={props.width}>
           <S.TopWrapper>
             <S.TopLabel>결제 정보</S.TopLabel>
           </S.TopWrapper>
           <S.SeperationForm>
             <S.FormLeftText color="gray">야놀자 구매가</S.FormLeftText>
-            <S.FormRightPrice color="black">{yanoljaPurchasePrice}원</S.FormRightPrice>
+            <S.FormRightPrice color="black">{props.yanoljaPurchasePrice}원</S.FormRightPrice>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormTextWrapper>
               <S.FormLeftText color="gray">양도할인가</S.FormLeftText>
-              <S.FormLeftText color="blue">({discountRate}% 할인)</S.FormLeftText>
+              <S.FormLeftText color="blue">({props.discountRate}% 할인)</S.FormLeftText>
             </S.FormTextWrapper>
-            <S.FormRightPrice color="gray">-{discountPrice}원</S.FormRightPrice>
+            <S.FormRightPrice color="gray">-{props.discountPrice}원</S.FormRightPrice>
           </S.SeperationForm>
 
-          {from === "purchase" || from === "cancel" ? (
+          {props.from === "purchase" || props.from === "cancel" ? (
             <S.SeperationForm>
               <S.FormTextWrapper>
                 <S.FormLeftText color="gray">수수료</S.FormLeftText>
                 <S.FormLeftText color="red">(야놀자페이 무료)</S.FormLeftText>
               </S.FormTextWrapper>
-              <S.FormRightPrice color="gray">{charge}원</S.FormRightPrice>
+              <S.FormRightPrice color="gray">{props.charge}원</S.FormRightPrice>
             </S.SeperationForm>
           ) : null}
 
           <S.SeperationForm isBorder={true}>
             <S.FormLeftTextBold>{textContent}</S.FormLeftTextBold>
-            <S.FormRightPrice color="blue">{yanabadaPurchasePrice}원</S.FormRightPrice>
+            <S.FormRightPrice color="blue">{props.yanabadaPurchasePrice}원</S.FormRightPrice>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>결제수단</S.FormLeftText>
-            <S.FormRightText>{payMethod}</S.FormRightText>
+            <S.FormRightText>{props.payMethod}</S.FormRightText>
           </S.SeperationForm>
         </S.InfoWrapper>
       );
     case "transactionInfo":
       return (
-        <S.InfoWrapper divType={divType} width={width}>
-          <S.TopWrapper width={width}>
+        <S.InfoWrapper divType={props.divType} width={props.width}>
+          <S.TopWrapper width={props.width}>
             <S.TopLabel>거래 정보</S.TopLabel>
-            {from === "purchase" || from === "cancel" ? (
+            {props.from === "purchase" || props.from === "cancel" ? (
               <S.ShortcutWrapper>
                 <S.ShortcutText>야놀자 바로가기</S.ShortcutText>
                 <YanoljaIcon />
@@ -98,24 +82,24 @@ const Info = ({
           <S.MiddleWrapper isBorder={true}>
             <S.FormLeftText color="gray">상품명</S.FormLeftText>
             <S.MiddleBottomWrapper>
-              <S.ImageWrapper imageURL={imageURL} />
+              <S.ImageWrapper imageURL={props.imageURL} />
               <S.MiddleBottomRightWrapper>
-                <S.AccomodationName>{accommodationName}</S.AccomodationName>
-                <S.RoomName>{roomName}</S.RoomName>
+                <S.AccomodationName>{props.accommodationName}</S.AccomodationName>
+                <S.RoomName>{props.roomName}</S.RoomName>
               </S.MiddleBottomRightWrapper>
             </S.MiddleBottomWrapper>
           </S.MiddleWrapper>
           <S.SeperationForm>
             <S.FormLeftText>주문번호</S.FormLeftText>
-            <S.FormRightText>{orderNumber}</S.FormRightText>
+            <S.FormRightText>{props.orderNumber}</S.FormRightText>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>구매자</S.FormLeftText>
-            <S.FormRightText>{buyer}</S.FormRightText>
+            <S.FormRightText>{props.buyer}</S.FormRightText>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>주문일시</S.FormLeftText>
-            <S.FormRightText>{orderDate}</S.FormRightText>
+            <S.FormRightText>{props.orderDate}</S.FormRightText>
           </S.SeperationForm>
         </S.InfoWrapper>
       );

--- a/src/pages/myPage/components/Info/index.tsx
+++ b/src/pages/myPage/components/Info/index.tsx
@@ -1,14 +1,51 @@
 import * as S from "./styles";
+import YanoljaIcon from "@assets/icons/YanoljaIcon.svg?react";
 
 interface PayInfoProps {
-  divType: "payInfo" | "transactionInfo";
+  divType: "payInfo" | "transactionInfo" | "payInfo-tall";
   width?: string;
   imageURL?: string;
+  yanoljaPurchasePrice?: string;
+  yanabadaPurchasePrice?: string;
+  discountRate?: number;
+  discountPrice?: string;
+  from?: string;
+  payMethod?: string;
+  accommodationName?: string;
+  roomName?: string;
+  orderNumber?: string;
+  buyer?: string;
+  orderDate?: string;
+  charge?: string;
 }
 
-const Info = ({ divType, width, imageURL }: PayInfoProps) => {
+const Info = ({
+  divType,
+  width,
+  imageURL,
+  yanoljaPurchasePrice,
+  yanabadaPurchasePrice,
+  discountRate,
+  discountPrice,
+  from,
+  payMethod,
+  accommodationName,
+  roomName,
+  orderNumber,
+  buyer,
+  orderDate,
+  charge
+}: PayInfoProps) => {
+  const textContent =
+    from === "sale"
+      ? "야나바다 판매가"
+      : from === "purchase" || from === "cancel"
+        ? "야나바다 구매가"
+        : "";
+
   switch (divType) {
     case "payInfo":
+    case "payInfo-tall":
       return (
         <S.InfoWrapper divType={divType} width={width}>
           <S.TopWrapper>
@@ -16,52 +53,69 @@ const Info = ({ divType, width, imageURL }: PayInfoProps) => {
           </S.TopWrapper>
           <S.SeperationForm>
             <S.FormLeftText color="gray">야놀자 구매가</S.FormLeftText>
-            <S.FormRightPrice color="black">1,200,000원</S.FormRightPrice>
-          </S.SeperationForm>
-          <S.SeperationForm isBorder={true}>
-            <S.FormTextWrapper>
-              <S.FormLeftText color="gray">양도할인가</S.FormLeftText>
-              <S.FormLeftText color="blue">(50% 할인)</S.FormLeftText>
-            </S.FormTextWrapper>
-            <S.FormRightPrice color="gray">-600,000원</S.FormRightPrice>
+            <S.FormRightPrice color="black">{yanoljaPurchasePrice}원</S.FormRightPrice>
           </S.SeperationForm>
           <S.SeperationForm>
-            <S.FormLeftTextBold>야나바다 판매가</S.FormLeftTextBold>
-            <S.FormRightPrice color="blue">600,000원</S.FormRightPrice>
+            <S.FormTextWrapper>
+              <S.FormLeftText color="gray">양도할인가</S.FormLeftText>
+              <S.FormLeftText color="blue">({discountRate}% 할인)</S.FormLeftText>
+            </S.FormTextWrapper>
+            <S.FormRightPrice color="gray">-{discountPrice}원</S.FormRightPrice>
+          </S.SeperationForm>
+
+          {from === "purchase" || from === "cancel" ? (
+            <S.SeperationForm>
+              <S.FormTextWrapper>
+                <S.FormLeftText color="gray">수수료</S.FormLeftText>
+                <S.FormLeftText color="red">(야놀자페이 무료)</S.FormLeftText>
+              </S.FormTextWrapper>
+              <S.FormRightPrice color="gray">{charge}원</S.FormRightPrice>
+            </S.SeperationForm>
+          ) : null}
+
+          <S.SeperationForm isBorder={true}>
+            <S.FormLeftTextBold>{textContent}</S.FormLeftTextBold>
+            <S.FormRightPrice color="blue">{yanabadaPurchasePrice}원</S.FormRightPrice>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>결제수단</S.FormLeftText>
-            <S.FormRightText>야놀자페이</S.FormRightText>
+            <S.FormRightText>{payMethod}</S.FormRightText>
           </S.SeperationForm>
         </S.InfoWrapper>
       );
     case "transactionInfo":
       return (
         <S.InfoWrapper divType={divType} width={width}>
-          <S.TopWrapper>
+          <S.TopWrapper width={width}>
             <S.TopLabel>거래 정보</S.TopLabel>
+            {from === "purchase" || from === "cancel" ? (
+              <S.ShortcutWrapper>
+                <S.ShortcutText>야놀자 바로가기</S.ShortcutText>
+                <YanoljaIcon />
+              </S.ShortcutWrapper>
+            ) : null}
           </S.TopWrapper>
           <S.MiddleWrapper isBorder={true}>
             <S.FormLeftText color="gray">상품명</S.FormLeftText>
             <S.MiddleBottomWrapper>
               <S.ImageWrapper imageURL={imageURL} />
               <S.MiddleBottomRightWrapper>
-                <S.AccomodationName>파라스파라 서울 더 그레이트 현대 런던 호텔</S.AccomodationName>
-                <S.RoomName>Forest Tower Deluxe King</S.RoomName>
+                <S.AccomodationName>{accommodationName}</S.AccomodationName>
+                <S.RoomName>{roomName}</S.RoomName>
               </S.MiddleBottomRightWrapper>
             </S.MiddleBottomWrapper>
           </S.MiddleWrapper>
           <S.SeperationForm>
             <S.FormLeftText>주문번호</S.FormLeftText>
-            <S.FormRightText>00000000</S.FormRightText>
+            <S.FormRightText>{orderNumber}</S.FormRightText>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>구매자</S.FormLeftText>
-            <S.FormRightText>USER12345</S.FormRightText>
+            <S.FormRightText>{buyer}</S.FormRightText>
           </S.SeperationForm>
           <S.SeperationForm>
             <S.FormLeftText>주문일시</S.FormLeftText>
-            <S.FormRightText>2024.01.06(토) 00:00</S.FormRightText>
+            <S.FormRightText>{orderDate}</S.FormRightText>
           </S.SeperationForm>
         </S.InfoWrapper>
       );

--- a/src/pages/myPage/components/Info/styles.ts
+++ b/src/pages/myPage/components/Info/styles.ts
@@ -11,7 +11,9 @@ interface TransactionStatementProps {
 export const InfoWrapper = styled.div<TransactionStatementProps>`
   width: ${({ width }) => width || "332px"};
   height: ${({ divType }) =>
-    (divType === "payInfo" && "244.993px") || (divType === "transactionInfo" && "300px")};
+    (divType === "payInfo" && "244.993px") ||
+    (divType === "payInfo-tall" && "270px") ||
+    (divType === "transactionInfo" && "300px")};
   padding: 14px 14px;
   display: flex;
   flex-direction: column;
@@ -24,9 +26,9 @@ export const TopWrapper = styled.div<TransactionStatementProps>`
   display: flex;
   width: ${({ width }) => width || "332px"};
   padding: 8px 0px;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 7px;
 `;
 
@@ -44,8 +46,8 @@ export const SeperationForm = styled.div<TransactionStatementProps>`
   gap: 10px;
   align-self: stretch;
 
-  border-bottom: ${({ isBorder }) => isBorder && "1px dashed #CCCCCC"};
-  padding-bottom: ${({ isBorder }) => isBorder && "12px"};
+  border-top: ${({ isBorder }) => isBorder && "1px dashed #CCCCCC"};
+  padding-top: ${({ isBorder }) => isBorder && "12px"};
 `;
 
 export const FormTextWrapper = styled.div`
@@ -53,7 +55,10 @@ export const FormTextWrapper = styled.div`
 `;
 
 export const FormLeftText = styled.p<TransactionStatementProps>`
-  color: ${({ color }) => (color === "gray" && "#9C9C9C") || (color === "blue" && "#38A3EB")};
+  color: ${({ color }) =>
+    (color === "gray" && "#9C9C9C") ||
+    (color === "blue" && "#38A3EB") ||
+    (color === "red" && "#DE2E5F")};
 
   /* [body2]본문 */
   ${({ theme }) => theme.text.body2}
@@ -140,4 +145,22 @@ export const RoomName = styled.p`
 
   /* [body2]본문 */
   ${({ theme }) => theme.text.body2}
+`;
+
+export const ShortcutWrapper = styled.div`
+  display: flex;
+  padding: 2px;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+
+  border-radius: 3px;
+  background: ${({ theme }) => theme.colors.gray[100]};
+`;
+
+export const ShortcutText = styled.p`
+  color: ${({ theme }) => theme.colors.gray[700]};
+
+  /* [Overline] 오버라인 */
+  ${({ theme }) => theme.text.overline}
 `;

--- a/src/pages/myPage/components/TransactionStatementNotice/index.tsx
+++ b/src/pages/myPage/components/TransactionStatementNotice/index.tsx
@@ -1,0 +1,45 @@
+import * as S from "./styles";
+import * as CS from "@components/notice/styles";
+import { RiErrorWarningFill } from "react-icons/ri";
+
+interface NoticeProps {
+  from: "sale" | "purchase" | "cancel";
+}
+
+const TransactionStatementNotice = ({ from }: NoticeProps) => {
+  switch (from) {
+    case "sale":
+      return (
+        <CS.NoticeWrapper className="lineFill yanolja">
+          <RiErrorWarningFill color="#028161" />
+          <S.SaleText>정상적으로 판매 완료된 주문입니다</S.SaleText>
+        </CS.NoticeWrapper>
+      );
+    case "purchase":
+      return (
+        <CS.NoticeWrapper className="lineFill yanolja">
+          <RiErrorWarningFill color="#028161" />
+          <S.TextWrapper>
+            <S.SaleText>정상적으로 구매 완료된 주문입니다</S.SaleText>
+            <S.DetailText>숙소정보는 야놀자 예약내역에서 확인해주세요</S.DetailText>
+          </S.TextWrapper>
+        </CS.NoticeWrapper>
+      );
+    case "cancel":
+      return (
+        <CS.NoticeWrapper className="lineFill yanolja">
+          <RiErrorWarningFill color="#9C9C9C" />
+          <S.TextWrapper>
+            <S.CancelText>구매 취소된 주문입니다.</S.CancelText>
+            <S.DetailText>
+              구매를 취소하셨거나 판매자가 승인을 거절하여 구매취소되었습니다.
+            </S.DetailText>
+          </S.TextWrapper>
+        </CS.NoticeWrapper>
+      );
+    default:
+      return null;
+  }
+};
+
+export default TransactionStatementNotice;

--- a/src/pages/myPage/components/TransactionStatementNotice/styles.ts
+++ b/src/pages/myPage/components/TransactionStatementNotice/styles.ts
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SaleText = styled.p`
+  color: var(--PassGreen, #028161);
+
+  /* [body2]본문 */
+  ${({ theme }) => theme.text.body2}
+`;
+
+export const CancelText = styled.p`
+  color: ${({ theme }) => theme.colors.gray[600]};
+
+  /* [body2]본문 */
+  ${({ theme }) => theme.text.body2}
+`;
+
+export const DetailText = styled.p`
+  color: ${({ theme }) => theme.colors.gray[700]};
+
+  /* [body2]본문 */
+  ${({ theme }) => theme.text.body2}
+`;

--- a/src/pages/myPage/purchaseHistory.tsx
+++ b/src/pages/myPage/purchaseHistory.tsx
@@ -1,5 +1,73 @@
-const PurchaseHistory = () => {
-  return <div>구매내역</div>;
+import * as S from "./styles/history.styles";
+import UpperNavBar from "@components/navBar/upperNavBar";
+import ListCard from "@components/card/ListCard";
+
+// FIXME: 모듈화
+interface PointsMiddleTabProps {
+  width?: string;
+}
+
+const PurchaseHistory = ({ width }: PointsMiddleTabProps) => {
+  return (
+    <>
+      <UpperNavBar title="구매내역" type="back" />
+      <S.PointsMiddleContainer width={width}>
+        <S.MiddleWrapper>
+          <S.MiddleLeftText>전체</S.MiddleLeftText>
+          <S.UnderLine />
+        </S.MiddleWrapper>
+        <S.MiddleWrapper>
+          <S.MiddleTextWrapper>
+            <S.MiddleRightText>승인대기</S.MiddleRightText>
+          </S.MiddleTextWrapper>
+        </S.MiddleWrapper>
+        <S.MiddleWrapper>
+          <S.MiddleTextWrapper>
+            <S.MiddleRightText>구매완료</S.MiddleRightText>
+          </S.MiddleTextWrapper>
+        </S.MiddleWrapper>
+        <S.MiddleWrapper>
+          <S.MiddleTextWrapper>
+            <S.MiddleRightText>구매취소</S.MiddleRightText>
+          </S.MiddleTextWrapper>
+        </S.MiddleWrapper>
+      </S.PointsMiddleContainer>
+      <S.ListCardWrapper width={width}>
+        <ListCard
+          cardType="approval_wait"
+          width={width}
+          imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+          accommodationName="파라스파라 서울 더 그레이트 현대..."
+          buyerInfo="물건판매자닉네임 | 야놀자페이 결제"
+          saleDate="2024.01.06(토) 00:00"
+          roomName="Forest Tower Deluxe King"
+          price="800,000"
+          badgeText="승인대기"
+        />
+        <ListCard
+          cardType="purchased"
+          width={width}
+          imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+          accommodationName="파라스파라 서울 더 그레이트 현대..."
+          buyerInfo="물건판매자닉네임 | 야놀자페이 결제"
+          saleDate="2024.01.06(토) 00:00"
+          roomName="Forest Tower Deluxe King"
+          price="800,000"
+          badgeText="구매완료"
+        />
+        <ListCard
+          cardType="purchasedCanceled"
+          width={width}
+          imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+          accommodationName="파라스파라 서울 더 그레이트 현대..."
+          buyerInfo="승인 거절 / 구매 취소에 의한 취소"
+          roomName="Forest Tower Deluxe King"
+          price="800,000"
+          badgeText="취소"
+        />
+      </S.ListCardWrapper>
+    </>
+  );
 };
 
 export default PurchaseHistory;

--- a/src/pages/myPage/salesHistory.tsx
+++ b/src/pages/myPage/salesHistory.tsx
@@ -1,13 +1,13 @@
-import * as S from "./styles/salesHistory.styles";
+import * as S from "./styles/history.styles";
 import UpperNavBar from "@components/navBar/upperNavBar";
 import ListCard from "@components/card/ListCard";
 
 // FIXME: 모듈화
-interface PointsMiddleTabProps {
+interface SalesHistoryProps {
   width?: string;
 }
 
-const SalesHistory = ({ width }: PointsMiddleTabProps) => {
+const SalesHistory = ({ width }: SalesHistoryProps) => {
   return (
     <>
       <UpperNavBar title="판매내역" type="back" />

--- a/src/pages/myPage/salesHistory.tsx
+++ b/src/pages/myPage/salesHistory.tsx
@@ -46,6 +46,7 @@ const SalesHistory = ({ width }: PointsMiddleTabProps) => {
           timerText="3일 15시간 23분"
           roomName="Forest Tower Deluxe King"
           price="800,000"
+          badgeText="판매중"
         />
         <ListCard
           cardType="saleCanceled"
@@ -55,6 +56,7 @@ const SalesHistory = ({ width }: PointsMiddleTabProps) => {
           buyerInfo="승인 거절 / 판매 종료에 의한 취소"
           roomName="Forest Tower Deluxe King"
           price="800,000"
+          badgeText="취소"
         />
         <ListCard
           cardType="saleEnd"
@@ -65,6 +67,7 @@ const SalesHistory = ({ width }: PointsMiddleTabProps) => {
           saleDate="2024.01.06(토) 00:00"
           roomName="Forest Tower Deluxe King"
           price="800,000"
+          badgeText="판매완료"
         />
       </S.ListCardWrapper>
     </>

--- a/src/pages/myPage/styles/history.styles.ts
+++ b/src/pages/myPage/styles/history.styles.ts
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 
 // FIXME: 모듈화
-interface PointsMiddleTabProps {
+interface SalesHistoryProps {
   width?: string;
 }
 
 /********** FIXME: 모듈화 **********/
 
-export const PointsMiddleContainer = styled.div<PointsMiddleTabProps>`
+export const PointsMiddleContainer = styled.div<SalesHistoryProps>`
   display: flex;
   width: ${({ width }) => width || "360px"};
   justify-content: space-between;
@@ -58,7 +58,7 @@ export const MiddleRightText = styled.p`
 /******************************/
 
 // FIXME: 모듈화
-export const ListCardWrapper = styled.div<PointsMiddleTabProps>`
+export const ListCardWrapper = styled.div<SalesHistoryProps>`
   width: ${({ width }) => width || "360px"};
   height: 850px;
   display: flex;

--- a/src/pages/myPage/transactionStatement.tsx
+++ b/src/pages/myPage/transactionStatement.tsx
@@ -1,31 +1,117 @@
 import UpperNavBar from "@components/navBar/upperNavBar";
 import * as S from "./styles/transactionStatement.styles";
-import Notice from "@components/notice";
 import Info from "./components/Info";
 import BaseButton from "@components/buttons/BaseButton";
+import TransactionStatementNotice from "./components/TransactionStatementNotice";
 
 interface TransactionStatementProps {
   width?: string;
+  from: "sale" | "purchase" | "cancel";
 }
 
-const TransactionStatement = ({ width }: TransactionStatementProps) => {
-  return (
-    <>
-      <UpperNavBar title="거래내역서" type="back" />
-      <S.ListCardWrapper width={width}>
-        <Notice type="info" content="정상적으로 판매 완료된 주문입니다" shape="lineFill" />
-        <Info divType="payInfo" width={width} />
-        <Info
-          divType="transactionInfo"
-          width={width}
-          imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
-        />
-        <BaseButton buttonType="transparent-red" width={width}>
-          거래내역 삭제
-        </BaseButton>
-      </S.ListCardWrapper>
-    </>
-  );
+const TransactionStatement = ({ width, from }: TransactionStatementProps) => {
+  switch (from) {
+    case "sale":
+      return (
+        <>
+          <UpperNavBar title="거래내역서" type="back" />
+          <S.ListCardWrapper width={width}>
+            <TransactionStatementNotice from="sale" />
+            <Info
+              divType="payInfo"
+              width={width}
+              yanoljaPurchasePrice="1,200,000"
+              yanabadaPurchasePrice="600,000"
+              discountRate={50}
+              discountPrice="600,000"
+              from="sale"
+              payMethod="야놀자페이"
+            />
+            <Info
+              divType="transactionInfo"
+              width={width}
+              imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+              accommodationName="파라스파라 서울 더 그레이트 현대..."
+              roomName="Forest Tower Deluxe King"
+              orderNumber="00000000"
+              buyer="USER12345"
+              orderDate="2024.01.06(토) 00:00"
+            />
+            <BaseButton buttonType="transparent-red" width={width}>
+              거래내역 삭제
+            </BaseButton>
+          </S.ListCardWrapper>
+        </>
+      );
+    case "purchase":
+      return (
+        <>
+          <UpperNavBar title="거래내역서" type="back" />
+          <S.ListCardWrapper width={width}>
+            <TransactionStatementNotice from="purchase" />
+            <Info
+              divType="payInfo-tall"
+              width={width}
+              yanoljaPurchasePrice="1,200,000"
+              yanabadaPurchasePrice="600,000"
+              discountRate={50}
+              discountPrice="600,000"
+              from="purchase"
+              payMethod="야놀자페이"
+              charge="0"
+            />
+            <Info
+              divType="transactionInfo"
+              width={width}
+              imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+              accommodationName="파라스파라 서울 더 그레이트 현대..."
+              roomName="Forest Tower Deluxe King"
+              orderNumber="00000000"
+              buyer="USER12345"
+              orderDate="2024.01.06(토) 00:00"
+              from="purchase"
+            />
+            <BaseButton buttonType="transparent-red" width={width}>
+              거래내역 삭제
+            </BaseButton>
+          </S.ListCardWrapper>
+        </>
+      );
+    case "cancel":
+      return (
+        <>
+          <UpperNavBar title="거래내역서" type="back" />
+          <S.ListCardWrapper width={width}>
+            <TransactionStatementNotice from="cancel" />
+            <Info
+              divType="payInfo-tall"
+              width={width}
+              yanoljaPurchasePrice="1,200,000"
+              yanabadaPurchasePrice="600,000"
+              discountRate={50}
+              discountPrice="600,000"
+              from="purchase"
+              payMethod="야놀자페이"
+              charge="0"
+            />
+            <Info
+              divType="transactionInfo"
+              width={width}
+              imageURL="https://s3-alpha-sig.figma.com/img/36c2/822d/857605b4a76677c08f70ec465ea3025b?Expires=1705881600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=TnWMooKbyWdNbRJ2LqPUd2wwxWSoyaeca-ZOnAQvkWzxGDGf8XmHfm8kXvpCIkuKwQszL6M58aoRVsHIiTA-Rdj5SkGexDQk6UtpqUMHr-Lj9UfZ~4PqUrVthW5DSVksw~oG465CJJMmTHFKDIsI~kj~uMwLWWS8MKkuqCDzgfZFBHjcRxcj57rO8uGvqQ526PqhKgwqkQlf2Fubf4b2qWOG75VV9M1xbd4fje4e2yiEKkwwTcPXQ3PCKR--M55PrB2b0ysG-QLjE-fY5SsH-pFgpoEXLXZFQKl65hSAlAsrcglFhJmK-8m-bltje-4aQSR1FkseHjsPl49KtCkfjw__"
+              accommodationName="파라스파라 서울 더 그레이트 현대..."
+              roomName="Forest Tower Deluxe King"
+              orderNumber="00000000"
+              buyer="USER12345"
+              orderDate="2024.01.06(토) 00:00"
+              from="purchase"
+            />
+            <BaseButton buttonType="transparent-red" width={width}>
+              거래내역 삭제
+            </BaseButton>
+          </S.ListCardWrapper>
+        </>
+      );
+  }
 };
 
 export default TransactionStatement;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,6 +6,7 @@ import Points from "@pages/myPage/points";
 import PointsMiddleTabList from "@pages/myPage/components/PointsMiddleTabList";
 import PointsMiddleTabDisappear from "@pages/myPage/components/PointsMiddleTabDisappear";
 import SalesHistory from "@pages/myPage/salesHistory";
+import PurchaseHistory from "@pages/myPage/purchaseHistory";
 import TransactionStatement from "@pages/myPage/transactionStatement";
 import Sell from "@pages/sell";
 import Products from "@pages/products";
@@ -123,10 +124,34 @@ const router = createBrowserRouter([
             )
           },
           {
-            path: "transactionStatement",
+            path: "transactionStatement/sale",
             element: (
               <>
-                <TransactionStatement width="100%" />
+                <TransactionStatement width="100%" from="sale" />
+              </>
+            )
+          },
+          {
+            path: "transactionStatement/purchase",
+            element: (
+              <>
+                <TransactionStatement width="100%" from="purchase" />
+              </>
+            )
+          },
+          {
+            path: "transactionStatement/cancel",
+            element: (
+              <>
+                <TransactionStatement width="100%" from="cancel" />
+              </>
+            )
+          },
+          {
+            path: "purchaseHistory",
+            element: (
+              <>
+                <PurchaseHistory width="100%" />
               </>
             )
           }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -117,43 +117,23 @@ const router = createBrowserRouter([
           },
           {
             path: "salesHistory",
-            element: (
-              <>
-                <SalesHistory width="100%" />
-              </>
-            )
+            element: <SalesHistory width="100%" />
           },
           {
             path: "transactionStatement/sale",
-            element: (
-              <>
-                <TransactionStatement width="100%" from="sale" />
-              </>
-            )
+            element: <TransactionStatement width="100%" from="sale" />
           },
           {
             path: "transactionStatement/purchase",
-            element: (
-              <>
-                <TransactionStatement width="100%" from="purchase" />
-              </>
-            )
+            element: <TransactionStatement width="100%" from="purchase" />
           },
           {
             path: "transactionStatement/cancel",
-            element: (
-              <>
-                <TransactionStatement width="100%" from="cancel" />
-              </>
-            )
+            element: <TransactionStatement width="100%" from="cancel" />
           },
           {
             path: "purchaseHistory",
-            element: (
-              <>
-                <PurchaseHistory width="100%" />
-              </>
-            )
+            element: <PurchaseHistory width="100%" />
           }
         ]
       }


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#51 

## 작업 내용 (변경 사항)
- ListCard 컴포넌트 badgeText 속성 추가
- Info 컴포넌트 props로 내용 받을수 있도록 변경
- 구매내역 페이지 디자인

## 스크린샷
- 구매내역
![image](https://github.com/Yanabada/Yanabada_FE/assets/93538221/ce95f7a6-b69a-4d84-8224-147daafaa9fd)

- 거래내역서
![image](https://github.com/Yanabada/Yanabada_FE/assets/93538221/bd28db16-3fe6-481d-9506-7f86995469d3)

- 거래내역서(취소시)
![image](https://github.com/Yanabada/Yanabada_FE/assets/93538221/63b25657-c6ea-46cc-92f7-41b9ded097f4)

## 테스트 결과
- 이상 무!

## 리뷰 요청 사항
- 디자인은 판매내역페이지(G-5)랑 유사하지만 props로 최대한 정보들을 전달하도록 변경하였습니다! 추가할 개선사항 있으면 커멘트 부탁드립니다.

close #51 
