### PR TITLE
Refactor: 검색 페이지 리팩토링 & 게스트 숫자 search params으로 관리

### DIFF
--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import DatePicker, { registerLocale, ReactDatePickerCustomHeaderProps } from "react-datepicker";
@@ -23,19 +23,21 @@ const Calendar = ({ excludeDates, renderDayContents }: calendarProp) => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  if (startDate) {
-    searchParams.set("start", startDate.toISOString());
-  } else {
-    searchParams.delete("start");
-  }
+  useEffect(() => {
+    if (startDate) {
+      searchParams.set("start", startDate.toISOString());
+    } else {
+      searchParams.delete("start");
+    }
 
-  if (endDate) {
-    searchParams.set("end", endDate.toISOString());
-  } else {
-    searchParams.delete("end");
-  }
+    if (endDate) {
+      searchParams.set("end", endDate.toISOString());
+    } else {
+      searchParams.delete("end");
+    }
 
-  setSearchParams(searchParams);
+    setSearchParams(searchParams);
+  }, [startDate, endDate, searchParams, setSearchParams]);
 
   const onChangeDate = (dates: [Date, Date]) => {
     const [start, end] = dates;

--- a/src/pages/products/components/KakaoMap/index.tsx
+++ b/src/pages/products/components/KakaoMap/index.tsx
@@ -42,10 +42,10 @@ const KakaoMap = () => {
             },
             isLoading: false
           }));
+          mapRef.current?.setLevel(5);
           mapRef.current?.setCenter(
             new kakao.maps.LatLng(position.coords.latitude, position.coords.longitude)
           );
-          mapRef.current?.setLevel(5);
         },
         (err) => {
           setState((prev) => ({

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -14,8 +14,9 @@ const Products = () => {
     <>
       <UpperNavBar
         title={isMapOpen ? "지도검색" : "상품리스트"}
-        type={isMapOpen ? "close" : "back"}
+        type={isMapOpen ? "backClose" : "back"}
         hasBorder={false}
+        isCustom={isMapOpen}
         {...(isMapOpen && { customBack: () => setMapOpen(false) })}
       />
       <S.Container>

--- a/src/pages/search/components/CalendarTab.tsx
+++ b/src/pages/search/components/CalendarTab.tsx
@@ -4,7 +4,7 @@ import { useSearchTab } from "../stores/tabStore";
 
 import CalendarIcon from "@assets/icons/search_Calendar.svg?react";
 import CalendarStore from "@stores/CalendarStore";
-import { format } from "date-fns";
+import { formatDateTo } from "@utils/formatDateTo";
 
 const CalendarTab = () => {
   const { tab, setTab } = useSearchTab();
@@ -12,7 +12,7 @@ const CalendarTab = () => {
 
   const changeDate = (date: Date | null) => {
     if (date) {
-      return format(date, "MM/dd");
+      return formatDateTo(date, "MM/dd");
     }
     return null;
   };

--- a/src/pages/search/components/CalendarTab.tsx
+++ b/src/pages/search/components/CalendarTab.tsx
@@ -10,15 +10,8 @@ const CalendarTab = () => {
   const { tab, setTab } = useSearchTab();
   const { searchStartDate, searchEndDate } = CalendarStore();
 
-  const changeDate = (date: Date | null) => {
-    if (date) {
-      return formatDateTo(date, "MM/dd");
-    }
-    return null;
-  };
-
-  const startDate = changeDate(searchStartDate);
-  const endDate = changeDate(searchEndDate);
+  const startDate = formatDateTo(searchStartDate, "MM/dd");
+  const endDate = formatDateTo(searchEndDate, "MM/dd");
 
   return (
     <SearchTab

--- a/src/pages/search/components/CalendarTab.tsx
+++ b/src/pages/search/components/CalendarTab.tsx
@@ -1,0 +1,36 @@
+import Calendar from "@components/calendar";
+import SearchTab from "./SearchTab";
+import { useSearchTab } from "../stores/tabStore";
+
+import CalendarIcon from "@assets/icons/search_Calendar.svg?react";
+import CalendarStore from "@stores/CalendarStore";
+import { format } from "date-fns";
+
+const CalendarTab = () => {
+  const { tab, setTab } = useSearchTab();
+  const { searchStartDate, searchEndDate } = CalendarStore();
+
+  const changeDate = (date: Date | null) => {
+    if (date) {
+      return format(date, "MM/dd");
+    }
+    return null;
+  };
+
+  const startDate = changeDate(searchStartDate);
+  const endDate = changeDate(searchEndDate);
+
+  return (
+    <SearchTab
+      isOpen={tab === "calendar"}
+      setIsOpen={() => setTab("calendar")}
+      icon={<CalendarIcon />}
+      leftPlaceholder="일정"
+      rightPlaceholder={startDate && endDate ? `${startDate} ~ ${endDate}` : "전체 일정"}
+    >
+      <Calendar />
+    </SearchTab>
+  );
+};
+
+export default CalendarTab;

--- a/src/pages/search/components/GuestCounterTab.tsx
+++ b/src/pages/search/components/GuestCounterTab.tsx
@@ -1,0 +1,23 @@
+import { useSearchTab } from "../stores/tabStore";
+import SearchTab from "./SearchTab";
+import GuestCounter from "./SearchTab/GuestCounter";
+
+import PersonIcon from "@assets/icons/search_Person.svg?react";
+
+const GuestCounterTab = () => {
+  const { tab, setTab } = useSearchTab();
+
+  return (
+    <SearchTab
+      isOpen={tab === "person"}
+      setIsOpen={() => setTab("person")}
+      icon={<PersonIcon />}
+      leftPlaceholder="인원"
+      rightPlaceholder="성인 2명"
+    >
+      <GuestCounter />
+    </SearchTab>
+  );
+};
+
+export default GuestCounterTab;

--- a/src/pages/search/components/KeywordTab.tsx
+++ b/src/pages/search/components/KeywordTab.tsx
@@ -1,0 +1,24 @@
+import SearchTab from "./SearchTab";
+import { useSearchTab } from "../stores/tabStore";
+import KeywordStore from "../stores/KeywordStore";
+import Keyword from "./SearchTab/Keyword";
+import SearchIcon from "@assets/icons/search_Search.svg?react";
+
+const KeywordTab = () => {
+  const { tab, setTab } = useSearchTab();
+  const { locationName } = KeywordStore();
+
+  return (
+    <SearchTab
+      isOpen={tab === "keyword"}
+      setIsOpen={() => setTab("keyword")}
+      icon={<SearchIcon />}
+      leftPlaceholder="키워드"
+      rightPlaceholder={locationName}
+    >
+      <Keyword />
+    </SearchTab>
+  );
+};
+
+export default KeywordTab;

--- a/src/pages/search/components/SearchTab/GuestCounter.tsx
+++ b/src/pages/search/components/SearchTab/GuestCounter.tsx
@@ -3,9 +3,31 @@ import * as S from "./guestCounter.style";
 import SearchNotice from "./SearchNotice";
 import MinusIcon from "@assets/icons/minus.svg?react";
 import PlusIcon from "@assets/icons/plus.svg?react";
+import { useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
 
 const GuestCounter = () => {
   const { adult, child, increaseAdult, decreaseAdult, increaseChild, decreaseChild } = useGuest();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    searchParams.set("adult", adult.toString());
+    searchParams.set("child", child.toString());
+
+    setSearchParams(`?${searchParams.toString()}`);
+  }, [adult, child, searchParams]);
+
+  const handleClick = (type: string) => {
+    if (type === "increaseAdult") {
+      increaseAdult();
+    } else if (type === "decreaseAdult") {
+      decreaseAdult();
+    } else if (type === "increaseChild") {
+      increaseChild();
+    } else {
+      decreaseChild();
+    }
+  };
 
   return (
     <S.Container>
@@ -13,11 +35,14 @@ const GuestCounter = () => {
       <S.Wrapper>
         <span>성인</span>
         <S.Wrapper>
-          <S.IconWrapper className={`${adult === 0 ? "" : "active"}`} onClick={decreaseAdult}>
+          <S.IconWrapper
+            className={`${adult === 0 ? "" : "active"}`}
+            onClick={() => handleClick("decreaseAdult")}
+          >
             <MinusIcon />
           </S.IconWrapper>
           <span>{adult}</span>
-          <S.IconWrapper className="active" onClick={increaseAdult}>
+          <S.IconWrapper className="active" onClick={() => handleClick("increaseAdult")}>
             <PlusIcon />
           </S.IconWrapper>
         </S.Wrapper>
@@ -26,11 +51,14 @@ const GuestCounter = () => {
       <S.Wrapper>
         <span>아동</span>
         <S.Wrapper>
-          <S.IconWrapper className={`${child === 0 ? "" : "active"}`} onClick={decreaseChild}>
+          <S.IconWrapper
+            className={`${child === 0 ? "" : "active"}`}
+            onClick={() => handleClick("decreaseChild")}
+          >
             <MinusIcon />
           </S.IconWrapper>
           <span>{child}</span>
-          <S.IconWrapper className="active" onClick={increaseChild}>
+          <S.IconWrapper className="active" onClick={() => handleClick("increaseChild")}>
             <PlusIcon />
           </S.IconWrapper>
         </S.Wrapper>

--- a/src/pages/search/components/SearchTab/SearchNotice.tsx
+++ b/src/pages/search/components/SearchTab/SearchNotice.tsx
@@ -4,7 +4,7 @@ import * as S from "./searchNotice.style";
 const SearchNotice = () => {
   return (
     <S.Container>
-      <Notice type="default" title="인원 미선택시 기본 성인 2명이 적용됩니다" />
+      <Notice type="info" content="인원 미선택시 기본 성인 2명이 적용됩니다" />
     </S.Container>
   );
 };

--- a/src/pages/search/components/SearchTab/guestCounter.style.ts
+++ b/src/pages/search/components/SearchTab/guestCounter.style.ts
@@ -20,7 +20,7 @@ export const Wrapper = styled(Flex)`
     color: ${({ theme }) => theme.colors.gray[700]};
   }
 
-  span:nth-child(2) {
+  span:nth-of-type(2) {
     width: 20px;
     text-align: center;
   }

--- a/src/pages/search/components/SearchTab/searchNotice.style.ts
+++ b/src/pages/search/components/SearchTab/searchNotice.style.ts
@@ -2,8 +2,6 @@ import styled from "@emotion/styled";
 
 export const Container = styled.div`
   div:first-of-type {
-    display: flex;
-    align-items: center;
     padding: 0;
   }
 

--- a/src/pages/search/components/SearchTab/styles.ts
+++ b/src/pages/search/components/SearchTab/styles.ts
@@ -7,7 +7,6 @@ interface SubtitleProps {
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 
   padding: 9px 16px;
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,36 +1,14 @@
-import { useState } from "react";
 import * as S from "./styles/style";
-import { format } from "date-fns";
-import SearchIcon from "@assets/icons/search_Search.svg?react";
-import CalendarIcon from "@assets/icons/search_Calendar.svg?react";
-import PersonIcon from "@assets/icons/search_Person.svg?react";
-import SearchTab from "./components/SearchTab";
 import BottomActions from "./components/BottomActions";
-import KeywordSearch from "./components/SearchTab/Keyword";
-import KeywordStore from "@pages/search/stores/KeywordStore";
 import UpperNavBar from "@components/navBar/upperNavBar";
-import GuestCounter from "./components/SearchTab/GuestCounter";
-import Calendar from "@components/calendar";
-import CalendarStore from "@stores/CalendarStore";
+import GuestCounterTab from "./components/GuestCounterTab";
+import CalendarTab from "./components/CalendarTab";
+import KeywordTab from "./components/KeywordTab";
 
 const Search = () => {
-  const [openTab, setOpenTab] = useState("keyword");
-  const { locationName } = KeywordStore();
-  const { searchStartDate, searchEndDate } = CalendarStore();
-
-  const changeDate = (date: Date | null) => {
-    if (date) {
-      return format(date, "MM/dd");
-    }
-    return null;
-  };
-
-  const startDate = changeDate(searchStartDate);
-  const endDate = changeDate(searchEndDate);
-
   return (
     <>
-      <UpperNavBar type="close" title="검색" />
+      <UpperNavBar type="back" title="검색" />
       <S.Container>
         <S.RecentSearchText>최근 검색 기록</S.RecentSearchText>
         <S.RecentSearchContainer>
@@ -76,33 +54,9 @@ const Search = () => {
           </S.RecordContainer>
         </S.RecentSearchContainer>
         <S.FilterText>검색 필터</S.FilterText>
-        <SearchTab
-          isOpen={openTab === "keyword"}
-          setIsOpen={() => setOpenTab("keyword")}
-          icon={<SearchIcon />}
-          leftPlaceholder="키워드"
-          rightPlaceholder={locationName}
-        >
-          <KeywordSearch />
-        </SearchTab>
-        <SearchTab
-          isOpen={openTab === "calendar"}
-          setIsOpen={() => setOpenTab("calendar")}
-          icon={<CalendarIcon />}
-          leftPlaceholder="일정"
-          rightPlaceholder={startDate && endDate ? `${startDate} ~ ${endDate}` : "전체 일정"}
-        >
-          <Calendar />
-        </SearchTab>
-        <SearchTab
-          isOpen={openTab === "person"}
-          setIsOpen={() => setOpenTab("person")}
-          icon={<PersonIcon />}
-          leftPlaceholder="인원"
-          rightPlaceholder="성인 2명"
-        >
-          <GuestCounter />
-        </SearchTab>
+        <KeywordTab />
+        <CalendarTab />
+        <GuestCounterTab />
         <BottomActions />
       </S.Container>
     </>

--- a/src/pages/search/stores/tabStore.ts
+++ b/src/pages/search/stores/tabStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type TabState = {
+  tab: string;
+  setTab: (newTab: string) => void;
+};
+
+export const useSearchTab = create<TabState>()((set) => ({
+  tab: "keyword",
+  setTab: (newTab) => set(() => ({ tab: newTab }))
+}));

--- a/src/utils/formatDateTo.ts
+++ b/src/utils/formatDateTo.ts
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 
-export const formatDateTo = (date: Date, formatOfDate: string = "MM/dd") => {
+export const formatDateTo = (date: Date | null, formatOfDate: string = "MM/dd") => {
+  if (!date) return;
   return format(date, formatOfDate);
 };


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#99 

## 작업 내용 (변경 사항)
- 각각의 검색 탭 컴포넌트 분리
- 게스트 숫자 변경 함수 공통화
- 게스트 숫자 관리 search params로 변경
- **searchParams 로직 useEffect 내부로 이동 (렌더링 도중에 router가 변경되면서 생기는 오류인 듯)**

## 스크린샷
![Jan-21-2024 22-25-38](https://github.com/Yanabada/Yanabada_FE/assets/123650056/6889f035-6110-4f81-90d8-7c77160c3179)

![Jan-21-2024 22-40-54](https://github.com/Yanabada/Yanabada_FE/assets/123650056/1cebb02f-94e0-4423-ab51-6b5588429262)

## 테스트 결과
- 이상 무!

## 리뷰 요청 사항

close #99 
