### PR TITLE
Feat: 마이페이지, 구매페이지 유효성 검사 로직 추가

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,5 +1,29 @@
-import axios from "axios";
+import axios, { AxiosInstance } from "axios";
 
-export const instance = axios.create({
-  baseURL: ""
+const instance: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: 5000
 });
+
+instance.interceptors.request.use(
+  async (config) => {
+    config.headers["Content-Type"] = "application/json";
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      alert("인증이 만료되어 재 로그인이 필요합니다.");
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default instance;

--- a/src/assets/icons/cancelIcon.svg
+++ b/src/assets/icons/cancelIcon.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9" cy="9" r="8" fill="#CCCCCC"/>
+<path d="M6 12L9 8.99999L6 6" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6L9 9.00001L12 12" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/buttons/AuthenticationButton/styles.ts
+++ b/src/components/buttons/AuthenticationButton/styles.ts
@@ -45,7 +45,7 @@ export const AbledAuthenticationButton = styled.button<AuthenticationButtonProps
 export const DisAbledAuthenticationButton = styled.button<AuthenticationButtonProps>`
   ${ButtonLayout}
   width: ${({ width }) => width || "332px"};
-  height: ${({ height }) => height || "auto"};
+  height: ${({ height }) => height || "28px"};
   border-radius: 5px;
   border: 1px solid ${({ theme }) => theme.colors.blue[200]};
 

--- a/src/components/buttons/CardSectionButton/index.tsx
+++ b/src/components/buttons/CardSectionButton/index.tsx
@@ -30,7 +30,8 @@ const CardSectionButton = ({ buttonType, width, onClick }: CardSectionProps) => 
             </S.ListButton>
           </S.ListButtonWrapper>
           <S.BottomSectionWrapper>
-            <S.BottomLeftButton buttonType={buttonType}>
+            {/* FIXME: 잔액인출 페이지 완성되면 이동 url 변경 */}
+            <S.BottomLeftButton buttonType={buttonType} onClick={() => navigate("/charge")}>
               <IoIosSearch size="18px" color="#DE2E5F" />
               <S.BottomLeftButtonText buttonType={buttonType}>잔액인출</S.BottomLeftButtonText>
             </S.BottomLeftButton>

--- a/src/components/certification/index.tsx
+++ b/src/components/certification/index.tsx
@@ -38,7 +38,7 @@ const Certification = ({
   phoneNum
 }: CertificationProps) => {
   const navigate = useNavigate();
-  const [isSendValid, setIsSendValid] = useState(false);
+  // const [isSendValid, setIsSendValid] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [openInput, setOpenInput] = useState(false);
   const [isNumCorrect, setIsNumCorrect] = useState(false);
@@ -71,21 +71,24 @@ const Certification = ({
     const formattedValue = formatPhoneNumber(e.target.value);
 
     setValue("phoneNumber", formattedValue);
-    if (formattedValue.length >= 12) {
-      setIsSendValid(true);
-    }
+    // if (formattedValue.length >= 12) {
+    //   setIsSendValid(true);
+    // }
   };
 
   // 인증번호 전송 남은 횟수
   const handleAuthenticationBtnClick = () => {
     // TODO - 인증번호 재전송 5회 소진시 동작 기획에 맞게 수정
-    if (!isSendValid || sentCount < 0) {
+    if (!isValid || sentCount < 0) {
       return;
     }
     setSentCount(sentCount - 1);
-    setBtnText(`인증번호 재전송(남은 횟수 ${sentCount}회)`);
     setIsModalVisible(true);
   };
+
+  useEffect(() => {
+    setBtnText(`인증번호 재전송(남은 횟수 ${sentCount}회)`);
+  }, [sentCount]);
 
   // 인증번호 유효성검사
   const isCodeValid = (value: number | null) => {
@@ -111,9 +114,7 @@ const Certification = ({
       setValue("phoneNumber", phoneNum);
       trigger("phoneNumber");
     }
-  }, [phoneNum, setValue, trigger]);
-
-  console.log("isValid:", isValid); // isValid를 콘솔에 로그
+  }, []);
 
   return (
     <>

--- a/src/components/certification/index.tsx
+++ b/src/components/certification/index.tsx
@@ -3,7 +3,7 @@ import * as S from "./styles";
 import TextInput from "@components/input/TextInput";
 import AuthenticationButton from "@components/buttons/AuthenticationButton";
 import { useForm } from "react-hook-form";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import Modal from "@components/modal";
 import ColoredButtonForm from "@components/buttons/ColoredButtonForm";
 import BottomSheet from "@components/bottomSheet";
@@ -18,6 +18,7 @@ interface CertificationProps {
   bottomSheetTitle?: string;
   bottomSheetChildren?: string | ReactNode;
   bottomSheetNavigate?: string;
+  phoneNum?: string | null;
 }
 
 interface FormData {
@@ -33,7 +34,8 @@ const Certification = ({
   hasBottomSheet,
   bottomSheetTitle,
   bottomSheetChildren,
-  bottomSheetNavigate
+  bottomSheetNavigate,
+  phoneNum
 }: CertificationProps) => {
   const navigate = useNavigate();
   const [isSendValid, setIsSendValid] = useState(false);
@@ -100,8 +102,14 @@ const Certification = ({
       return;
     }
     hasBottomSheet && setIsSheetVisible(true);
-    customHandleClick;
+    customHandleClick && customHandleClick();
   };
+
+  useEffect(() => {
+    if (phoneNum) {
+      setValue("phoneNumber", phoneNum);
+    }
+  }, []);
 
   return (
     <>

--- a/src/components/certification/index.tsx
+++ b/src/components/certification/index.tsx
@@ -49,8 +49,9 @@ const Certification = ({
   const {
     register,
     setValue,
-    formState: { errors },
-    getValues
+    formState: { errors, isValid },
+    getValues,
+    trigger
   } = useForm<FormData>({
     mode: "onBlur"
   });
@@ -108,8 +109,11 @@ const Certification = ({
   useEffect(() => {
     if (phoneNum) {
       setValue("phoneNumber", phoneNum);
+      trigger("phoneNumber");
     }
-  }, []);
+  }, [phoneNum, setValue, trigger]);
+
+  console.log("isValid:", isValid); // isValid를 콘솔에 로그
 
   return (
     <>
@@ -130,7 +134,7 @@ const Certification = ({
             errorMessage={errors.phoneNumber && `${errors.phoneNumber?.message}`}
           />
           <AuthenticationButton
-            buttonType={isSendValid ? "disabled" : "abled"}
+            buttonType={isValid ? "disabled" : "abled"}
             width={width}
             onClick={handleAuthenticationBtnClick}
           >

--- a/src/components/chips/ManipulationChip/styles.ts
+++ b/src/components/chips/ManipulationChip/styles.ts
@@ -29,6 +29,8 @@ export const DisabledDefaultChipWrapper = styled.button`
   ${WrapperLayout}
 
   background: ${({ theme }) => theme.colors.gray[100]};
+
+  cursor: not-allowed;
 `;
 
 export const DisabledChipText = styled.p`

--- a/src/components/input/TextInput/styles.ts
+++ b/src/components/input/TextInput/styles.ts
@@ -61,8 +61,6 @@ export const RightElement = styled.button`
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-
-  pointer-events: none;
 `;
 
 export const ErrorMessage = styled.p`

--- a/src/pages/myPage/profile.tsx
+++ b/src/pages/myPage/profile.tsx
@@ -20,6 +20,7 @@ interface ProfileProps {
 
 const Profile = ({ width }: ProfileProps) => {
   const [isEditIconClicked, setIsEditIconClicked] = useState(false);
+  const [nickName, setNickName] = useState("강쥐사랑해");
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -71,17 +72,26 @@ const Profile = ({ width }: ProfileProps) => {
                   <ManipulationChip
                     buttonType={!errors.nickName ? "abledDefault" : "disabledDefault"}
                     type="submit"
+                    onClick={() => {
+                      setNickName(getValues("nickName"));
+                      setIsEditIconClicked(false);
+                    }}
                   >
                     확인
                   </ManipulationChip>
-                  <ManipulationChip buttonType="disabledDefault">취소</ManipulationChip>
+                  <ManipulationChip
+                    buttonType="disabledDefault"
+                    onClick={() => setIsEditIconClicked(false)}
+                  >
+                    취소
+                  </ManipulationChip>
                 </S.TextInputBottomWrapper>
               </form>
             </S.FormWrapper>
           ) : (
             <>
               <S.ProfileTextWrapper>
-                <S.ProfileText>강쥐사랑해</S.ProfileText>
+                <S.ProfileText>{nickName}</S.ProfileText>
                 <S.EditIconWrapper onClick={() => setIsEditIconClicked(true)}>
                   <EditIcon />
                 </S.EditIconWrapper>

--- a/src/pages/myPage/profile.tsx
+++ b/src/pages/myPage/profile.tsx
@@ -7,6 +7,11 @@ import CheckIcon from "@assets/icons/checkbox_Check.svg?react";
 import { Input, Icon } from "@components/input/Checkbox/allConsentCheckbox.style";
 import SwitchButton from "@components/buttons/SwitchButton";
 import ArrowForwardIcon from "@assets/icons/arrowForwardIconLight.svg?react";
+import { useState } from "react";
+import TextInput from "@components/input/TextInput";
+import ManipulationChip from "@components/chips/ManipulationChip";
+import CancelIcon from "@assets/icons/cancelIcon.svg?react";
+import { useForm } from "react-hook-form";
 
 interface ProfileProps {
   width?: string;
@@ -14,6 +19,26 @@ interface ProfileProps {
 }
 
 const Profile = ({ width }: ProfileProps) => {
+  const [isEditIconClicked, setIsEditIconClicked] = useState(false);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (errors.nickName) return;
+    // FIXME: API 연동
+    console.log("submit");
+    const nickName = getValues("nickName");
+    console.log("nickName", nickName);
+  };
+
+  const {
+    register,
+    formState: { errors },
+    getValues,
+    setValue
+  } = useForm({
+    mode: "onBlur"
+  });
+
   return (
     <>
       <UpperNavBar title="내 정보 관리" type="back" />
@@ -22,11 +47,47 @@ const Profile = ({ width }: ProfileProps) => {
           {/* FIXME: 추후 DB에서 받아온 이미지로 변경 예정 */}
           {/* <S.ProfileImage imageURL={imageURL} /> */}
           <ProfileImg />
-          <S.ProfileTextWrapper>
-            <S.ProfileText>강쥐사랑해</S.ProfileText>
-            <EditIcon />
-          </S.ProfileTextWrapper>
-          <S.EmailText>email*****@gmail.com</S.EmailText>
+          {isEditIconClicked ? (
+            <S.FormWrapper width={width}>
+              <form onSubmit={onSubmit}>
+                <S.TextInputWrapper width={width}>
+                  <TextInput
+                    variant="move"
+                    label="닉네임"
+                    rightElement={<CancelIcon />}
+                    onRightElementClick={() => setValue("nickName", "")}
+                    {...register("nickName", {
+                      required: true,
+                      pattern: {
+                        value: /^[가-힣a-zA-Z0-9]{2,8}$/,
+                        message: "2~8자 한글/영문/숫자만 가능합니다."
+                      }
+                    })}
+                    errorMessage={errors.nickName && `${errors.nickName?.message}`}
+                  />
+                </S.TextInputWrapper>
+                <S.TextInputBottomWrapper width={width}>
+                  <ManipulationChip
+                    buttonType={!errors.nickName ? "abledDefault" : "disabledDefault"}
+                    type="submit"
+                  >
+                    확인
+                  </ManipulationChip>
+                  <ManipulationChip buttonType="disabledDefault">취소</ManipulationChip>
+                </S.TextInputBottomWrapper>
+              </form>
+            </S.FormWrapper>
+          ) : (
+            <>
+              <S.ProfileTextWrapper>
+                <S.ProfileText>강쥐사랑해</S.ProfileText>
+                <S.EditIconWrapper onClick={() => setIsEditIconClicked(true)}>
+                  <EditIcon />
+                </S.EditIconWrapper>
+              </S.ProfileTextWrapper>
+              <S.EmailText>email*****@gmail.com</S.EmailText>
+            </>
+          )}
         </S.ProfileWrapper>
 
         <Spacer width={width} />

--- a/src/pages/myPage/profile.tsx
+++ b/src/pages/myPage/profile.tsx
@@ -29,7 +29,7 @@ const Profile = ({ width }: ProfileProps) => {
           <S.EmailText>email*****@gmail.com</S.EmailText>
         </S.ProfileWrapper>
 
-        <Spacer />
+        <Spacer width={width} />
 
         <S.PersonalInfoWrapper gap="16px">
           <S.Label>개인정보</S.Label>
@@ -76,7 +76,7 @@ const Profile = ({ width }: ProfileProps) => {
           </S.PersonalInfoTextWrapper>
         </S.PersonalInfoWrapper>
 
-        <Spacer />
+        <Spacer width={width} />
 
         <S.PersonalInfoWrapper gap="16px">
           <S.Label>광고성 정보 수신동의</S.Label>
@@ -103,7 +103,7 @@ const Profile = ({ width }: ProfileProps) => {
           </S.CheckBoxContainer>
         </S.PersonalInfoWrapper>
 
-        <Spacer />
+        <Spacer width={width} />
 
         <S.PersonalInfoWrapper gap="16px">
           <S.SwitchLabel>
@@ -115,7 +115,7 @@ const Profile = ({ width }: ProfileProps) => {
           </S.SwitchLabel>
         </S.PersonalInfoWrapper>
 
-        <Spacer />
+        <Spacer width={width} />
 
         <S.PersonalInfoWrapper gap="16px">
           <S.WithdrawalWrapper>

--- a/src/pages/myPage/profile.tsx
+++ b/src/pages/myPage/profile.tsx
@@ -26,6 +26,7 @@ const Profile = ({ width }: ProfileProps) => {
     if (errors.nickName) return;
     // FIXME: API 연동
     console.log("submit");
+
     const nickName = getValues("nickName");
     console.log("nickName", nickName);
   };

--- a/src/pages/myPage/styles/profile.styles.ts
+++ b/src/pages/myPage/styles/profile.styles.ts
@@ -208,3 +208,28 @@ export const WithdrawalWrapper = styled.div<ProfileProps>`
   align-items: center;
   flex-shrink: 0;
 `;
+
+export const EditIconWrapper = styled.div`
+  display: flex;
+`;
+
+export const TextInputWrapper = styled.div<ProfileProps>`
+  width: ${({ width }) => width || "332px"};
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+`;
+
+export const TextInputBottomWrapper = styled.div<ProfileProps>`
+  display: flex;
+  width: ${({ width }) => width || "332px"};
+  justify-content: flex-end;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 16px;
+`;
+
+export const FormWrapper = styled.div<ProfileProps>`
+  width: ${({ width }) => width || "332px"};
+`;

--- a/src/pages/purchase/index.tsx
+++ b/src/pages/purchase/index.tsx
@@ -23,6 +23,7 @@ import AuthenticationButton from "@components/buttons/AuthenticationButton";
 import Modal from "@components/modal";
 import { useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
+import { useSearchParams } from "react-router-dom";
 
 interface PurchaseProps {
   width?: string;
@@ -108,7 +109,9 @@ const Purchase = ({
     console.log("name1", name1);
     console.log("phoneNumber1", phoneNumber1);
 
-    navigate("/signin?from=changePassword&redirect=/purchase");
+    navigate(
+      `/signin/3?from=changeReservationInfo&name=${name1}&phonenumber=${phoneNumber1}&redirect=/purchase`
+    );
   };
 
   const {
@@ -119,6 +122,10 @@ const Purchase = ({
   } = useForm({
     mode: "onBlur"
   });
+
+  const [searchParams] = useSearchParams();
+  const name = searchParams.get("name");
+  const phoneNumber = searchParams.get("phonenumber");
 
   useEffect(() => {
     if (isChecked3 && isChecked4) {
@@ -249,7 +256,10 @@ const Purchase = ({
               </form>
             </S.FormWrapper>
           ) : (
-            <S.PersonInfoBottomWrapper>김팔자 / 010-1234-5678</S.PersonInfoBottomWrapper>
+            <S.PersonInfoBottomWrapper>
+              {/* FIXME: name과 phoneNumber값이 없으면 api 호출하여 렌더링 */}
+              {name ? name : "김팔자"} / {phoneNumber ? phoneNumber : "010-1234-5678"}
+            </S.PersonInfoBottomWrapper>
           )}
         </S.PersonInfoWrapper>
       </S.ReservationContainer>

--- a/src/pages/purchase/index.tsx
+++ b/src/pages/purchase/index.tsx
@@ -22,6 +22,7 @@ import BaseButton from "@components/buttons/BaseButton";
 import AuthenticationButton from "@components/buttons/AuthenticationButton";
 import Modal from "@components/modal";
 import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
 
 interface PurchaseProps {
   width?: string;
@@ -95,6 +96,26 @@ const Purchase = ({
     setPaymentMethod(selectedMethod);
   };
 
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (errors.nickName) return;
+    // FIXME: API 연동
+    console.log("submit");
+
+    const name = getValues("name");
+    const phoneNumber = getValues("phoneNumber");
+    console.log("name", name);
+    console.log("phoneNumber", phoneNumber);
+  };
+
+  const {
+    register,
+    formState: { errors },
+    getValues
+  } = useForm({
+    mode: "onBlur"
+  });
+
   useEffect(() => {
     if (isChecked3 && isChecked4) {
       setIsAllChecked(true);
@@ -162,33 +183,53 @@ const Purchase = ({
             <S.ChangeText onClick={() => setIsChangeButtonClicked(true)}>변경하기</S.ChangeText>
           </S.PersonInfoTopWrapper>
           {isChangeButtonClicked ? (
-            <>
-              <TextInput
-                variant="move"
-                label={
-                  <>
-                    <span>성명</span>
-                    <span style={{ color: "#E01F3E" }}>*</span>
-                  </>
-                }
-                errorMessage="이용자 이름은 한글과 영문만 가능합니다."
-              />
-              <TextInput
-                variant="move"
-                label={
-                  <>
-                    <span>휴대폰 번호</span>
-                    <span style={{ color: "#E01F3E" }}>*</span>
-                  </>
-                }
-                errorMessage="이용자 이름은 한글과 영문만 가능합니다."
-              />
-              <S.ChipWrapper>
-                {/* FIXME: 유효성 검사 후 input을 모두 채워야지만 abled되게 변경 */}
-                {/* FIXME: 휴대폰 인증 페이지(H-2) 라우터 추가 후 이동 로직 추가 */}
-                <ManipulationChip buttonType="abledDefault">인증 변경하기</ManipulationChip>
-              </S.ChipWrapper>
-            </>
+            <S.FormWrapper width={width}>
+              <form onSubmit={onSubmit}>
+                <S.TextInputWrapper>
+                  <TextInput
+                    variant="move"
+                    label={
+                      <>
+                        <span>성명</span>
+                        <span style={{ color: "#E01F3E" }}>*</span>
+                      </>
+                    }
+                    {...register("name", {
+                      required: true,
+                      pattern: {
+                        value: /^[가-힣a-zA-Z]*$/,
+                        message: "이용자 이름은 한글과 영문만 가능합니다."
+                      }
+                    })}
+                    errorMessage={errors.name && `${errors.name?.message}`}
+                  />
+                  <S.TextInputSpacer />
+                  <TextInput
+                    variant="move"
+                    label={
+                      <>
+                        <span>휴대폰 번호</span>
+                        <span style={{ color: "#E01F3E" }}>*</span>
+                      </>
+                    }
+                    {...register("phoneNumber", {
+                      required: true,
+                      pattern: {
+                        value: /^010-\d{4}-\d{4}$/,
+                        message: "010-0000-0000 형태로 입력해주세요."
+                      }
+                    })}
+                    errorMessage={errors.phoneNumber && `${errors.phoneNumber?.message}`}
+                  />
+                </S.TextInputWrapper>
+
+                <S.ChipWrapper>
+                  {/* FIXME: 유효성 검사 후 input을 모두 채워야지만 abled되게 변경 */}
+                  {/* FIXME: 휴대폰 인증 페이지(H-2) 라우터 추가 후 이동 로직 추가 */}
+                  <ManipulationChip buttonType="abledDefault">인증 변경하기</ManipulationChip>
+                </S.ChipWrapper>
+              </form>
+            </S.FormWrapper>
           ) : (
             <S.PersonInfoBottomWrapper>김팔자 / 010-1234-5678</S.PersonInfoBottomWrapper>
           )}
@@ -212,26 +253,47 @@ const Purchase = ({
             fontWeight="normal"
             setList={[setIsChecked1]}
           />
-          <TextInput
-            variant="move"
-            label={
-              <>
-                <span>성명</span>
-                <span style={{ color: "#E01F3E" }}>*</span>
-              </>
-            }
-            errorMessage="이용자 이름은 한글과 영문만 가능합니다."
-          />
-          <TextInput
-            variant="move"
-            label={
-              <>
-                <span>휴대폰 번호</span>
-                <span style={{ color: "#E01F3E" }}>*</span>
-              </>
-            }
-            errorMessage="이용자 이름은 한글과 영문만 가능합니다."
-          />
+          <S.FormWrapper width={width}>
+            <form onSubmit={onSubmit}>
+              <S.TextInputWrapper>
+                <TextInput
+                  variant="move"
+                  label={
+                    <>
+                      <span>성명</span>
+                      <span style={{ color: "#E01F3E" }}>*</span>
+                    </>
+                  }
+                  {...register("name", {
+                    required: true,
+                    pattern: {
+                      value: /^[가-힣a-zA-Z]*$/,
+                      message: "이용자 이름은 한글과 영문만 가능합니다."
+                    }
+                  })}
+                  errorMessage={errors.name && `${errors.name?.message}`}
+                />
+                <S.TextInputSpacer />
+                <TextInput
+                  variant="move"
+                  label={
+                    <>
+                      <span>휴대폰 번호</span>
+                      <span style={{ color: "#E01F3E" }}>*</span>
+                    </>
+                  }
+                  {...register("phoneNumber", {
+                    required: true,
+                    pattern: {
+                      value: /^010-\d{4}-\d{4}$/,
+                      message: "010-0000-0000 형태로 입력해주세요."
+                    }
+                  })}
+                  errorMessage={errors.phoneNumber && `${errors.phoneNumber?.message}`}
+                />
+              </S.TextInputWrapper>
+            </form>
+          </S.FormWrapper>
         </S.CheckBoxWrapper>
       </S.ReservationContainer>
       <S.ReservationContainer width={width}>

--- a/src/pages/purchase/index.tsx
+++ b/src/pages/purchase/index.tsx
@@ -98,20 +98,24 @@ const Purchase = ({
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (errors.nickName) return;
+
+    if (errors.name1 || errors.phoneNumber1) return;
     // FIXME: API 연동
     console.log("submit");
 
-    const name = getValues("name");
-    const phoneNumber = getValues("phoneNumber");
-    console.log("name", name);
-    console.log("phoneNumber", phoneNumber);
+    const name1 = getValues("name1");
+    const phoneNumber1 = getValues("phoneNumber1");
+    console.log("name1", name1);
+    console.log("phoneNumber1", phoneNumber1);
+
+    navigate("/signin?from=changePassword&redirect=/purchase");
   };
 
   const {
     register,
     formState: { errors },
-    getValues
+    getValues,
+    trigger
   } = useForm({
     mode: "onBlur"
   });
@@ -123,6 +127,13 @@ const Purchase = ({
       setIsAllChecked(false);
     }
   }, [isChecked1, isChecked2, isChecked3, isChecked4]);
+
+  useEffect(() => {
+    trigger("name1");
+    trigger("name2");
+    trigger("phoneNumber1");
+    trigger("phoneNumber2");
+  }, [trigger]);
 
   return (
     <>
@@ -194,14 +205,14 @@ const Purchase = ({
                         <span style={{ color: "#E01F3E" }}>*</span>
                       </>
                     }
-                    {...register("name", {
+                    {...register("name1", {
                       required: true,
                       pattern: {
                         value: /^[가-힣a-zA-Z]*$/,
                         message: "이용자 이름은 한글과 영문만 가능합니다."
                       }
                     })}
-                    errorMessage={errors.name && `${errors.name?.message}`}
+                    errorMessage={errors.name1 && `${errors.name1?.message}`}
                   />
                   <S.TextInputSpacer />
                   <TextInput
@@ -212,21 +223,28 @@ const Purchase = ({
                         <span style={{ color: "#E01F3E" }}>*</span>
                       </>
                     }
-                    {...register("phoneNumber", {
+                    {...register("phoneNumber1", {
                       required: true,
                       pattern: {
                         value: /^010-\d{4}-\d{4}$/,
                         message: "010-0000-0000 형태로 입력해주세요."
                       }
                     })}
-                    errorMessage={errors.phoneNumber && `${errors.phoneNumber?.message}`}
+                    errorMessage={errors.phoneNumber1 && `${errors.phoneNumber1?.message}`}
                   />
                 </S.TextInputWrapper>
 
                 <S.ChipWrapper>
                   {/* FIXME: 유효성 검사 후 input을 모두 채워야지만 abled되게 변경 */}
                   {/* FIXME: 휴대폰 인증 페이지(H-2) 라우터 추가 후 이동 로직 추가 */}
-                  <ManipulationChip buttonType="abledDefault">인증 변경하기</ManipulationChip>
+                  <ManipulationChip
+                    buttonType={
+                      !errors.name1 && !errors.phoneNumber1 ? "abledDefault" : "disabledDefault"
+                    }
+                    type="submit"
+                  >
+                    인증 변경하기
+                  </ManipulationChip>
                 </S.ChipWrapper>
               </form>
             </S.FormWrapper>
@@ -254,7 +272,7 @@ const Purchase = ({
             setList={[setIsChecked1]}
           />
           <S.FormWrapper width={width}>
-            <form onSubmit={onSubmit}>
+            <form>
               <S.TextInputWrapper>
                 <TextInput
                   variant="move"
@@ -264,14 +282,14 @@ const Purchase = ({
                       <span style={{ color: "#E01F3E" }}>*</span>
                     </>
                   }
-                  {...register("name", {
+                  {...register("name2", {
                     required: true,
                     pattern: {
                       value: /^[가-힣a-zA-Z]*$/,
                       message: "이용자 이름은 한글과 영문만 가능합니다."
                     }
                   })}
-                  errorMessage={errors.name && `${errors.name?.message}`}
+                  errorMessage={errors.name2 && `${errors.name2?.message}`}
                 />
                 <S.TextInputSpacer />
                 <TextInput
@@ -282,14 +300,14 @@ const Purchase = ({
                       <span style={{ color: "#E01F3E" }}>*</span>
                     </>
                   }
-                  {...register("phoneNumber", {
+                  {...register("phoneNumber2", {
                     required: true,
                     pattern: {
                       value: /^010-\d{4}-\d{4}$/,
                       message: "010-0000-0000 형태로 입력해주세요."
                     }
                   })}
-                  errorMessage={errors.phoneNumber && `${errors.phoneNumber?.message}`}
+                  errorMessage={errors.phoneNumber2 && `${errors.phoneNumber2?.message}`}
                 />
               </S.TextInputWrapper>
             </form>

--- a/src/pages/purchase/styles/styles.ts
+++ b/src/pages/purchase/styles/styles.ts
@@ -211,6 +211,8 @@ export const ChipWrapper = styled.div`
   width: 100%;
   justify-content: flex-end;
   align-items: center;
+
+  margin-top: 16px;
 `;
 
 export const ToggleButtonWrapper = styled.div`
@@ -265,4 +267,20 @@ export const BottomDetailTextBlue = styled.span`
   line-height: 18px; /* 150% */
   letter-spacing: -0.24px;
   text-decoration-line: underline;
+`;
+
+export const FormWrapper = styled.div<PurchaseProps>`
+  width: ${({ width }) => width || "332px"};
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TextInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+`;
+
+export const TextInputSpacer = styled.div`
+  margin-top: 20px;
 `;

--- a/src/pages/signIn/components/signInFourth/SignInFourth.tsx
+++ b/src/pages/signIn/components/signInFourth/SignInFourth.tsx
@@ -1,21 +1,41 @@
 import Certification from "@components/certification";
 import { useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const SignInFourth = () => {
   const [searchParams] = useSearchParams();
   const providerParams = searchParams.get("provider");
+  const fromParams = searchParams.get("from");
+  const name = searchParams.get("name");
+  const phoneNumber = searchParams.get("phonenumber");
 
-  return (
-    <Certification
-      width="100%"
-      upperNavBarText={providerParams === "kakao" ? "회원가입(2/2)" : "회원가입(4/4)"}
-      buttonText="회원가입 완료"
-      hasBottomSheet
-      bottomSheetTitle="⠀"
-      bottomSheetChildren="회원가입 완료 추카추카~~ 추카 이미지 추가추가"
-      bottomSheetNavigate="/"
-    />
-  );
+  const navigate = useNavigate();
+
+  if (fromParams === "changeReservationInfo") {
+    return (
+      <Certification
+        width="100%"
+        upperNavBarText="예약자 정보 수정"
+        buttonText="확인"
+        customHandleClick={() => {
+          navigate(`/purchase?name=${name}&phonenumber=${phoneNumber}`);
+        }}
+        phoneNum={phoneNumber}
+      />
+    );
+  } else {
+    return (
+      <Certification
+        width="100%"
+        upperNavBarText={providerParams === "kakao" ? "회원가입(2/2)" : "회원가입(4/4)"}
+        buttonText="회원가입 완료"
+        hasBottomSheet
+        bottomSheetTitle="⠀"
+        bottomSheetChildren="회원가입 완료 추카추카~~ 추카 이미지 추가추가"
+        bottomSheetNavigate="/"
+      />
+    );
+  }
 };
 
 export default SignInFourth;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#97 

## 작업 내용 (변경 사항)
- profile 페이지 스페이서 width 설정
- 회원프로필(G-2) 닉네임 변경기능 추가 및 에러케이스 처리
- 잔액인출버튼 이동 로직 추가
- 구매페이지(H-1) 에러케이스 처리
- 예약자 변경 시 input을 모두 채워야 버튼 활성화되게 변경
- instance 설정
- 예약자 정보 수정 로직 추가
- 올바른 휴대폰 번호를 설정해주어도 버튼이 비활성화되어있는 현상 수정
- 닉네임 변경시 확인, 취소버튼 핸들러 함수 추가

## 스크린샷
- 회원프로필 닉네임 변경기능 추가 및 에러케이스 처리
![1](https://github.com/Yanabada/Yanabada_FE/assets/93538221/7dbf1f46-3c1e-4991-9d5f-41b604973146)
- 구매페이지 에러케이스 처리 및 페이지 이동시 휴대폰 번호 자동입력
![2](https://github.com/Yanabada/Yanabada_FE/assets/93538221/1497eccb-148a-4cd4-8a86-ba7f3494ad16)
- 예약자 정보 수정 로직
![3](https://github.com/Yanabada/Yanabada_FE/assets/93538221/09c04c3e-d286-44af-90cf-1488c8566de0)

## 테스트 결과
휴대폰 번호 자동입력 후 blur 이벤트를 주어야 인증번호 전송 버튼이 클릭되는데 솔미랑 이야기 해봐야할것 같습니당!!
ㄴ 해결 완!

## 리뷰 요청 사항
@furaha707 누나 휴대폰 인증 페이지로 넘어갈때 querystring으로 
![image](https://github.com/Yanabada/Yanabada_FE/assets/93538221/17f5ccc2-8612-4ce2-9076-ac798bba7a0f)
`phoneNumber` 넘겨주면 자동으로 input필드 입력되게 해놨어!

close #97 
