### PR TITLE
[Fix & Design] 닉네임 중복 조회 API 에러 해결 & 로딩애니추가

### DIFF
--- a/src/components/checkNickname/index.tsx
+++ b/src/components/checkNickname/index.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import SignInDataStore from "@pages/signIn/stores/SignInDataStore";
 import compareNicknameApi from "@pages/signIn/apis/compareNicknameApi";
+import { Toaster } from "react-hot-toast";
 interface FormData {
   nickname: string;
 }
@@ -68,6 +69,7 @@ const CheckNickname = ({ title, to }: CheckNicknameProps) => {
 
   return (
     <>
+      <Toaster />
       <UpperNavBar type="back" title={title} />
 
       <TextInput

--- a/src/components/checkNickname/index.tsx
+++ b/src/components/checkNickname/index.tsx
@@ -33,7 +33,7 @@ const CheckNickname = ({ title, to }: CheckNicknameProps) => {
     getValues,
     setError
   } = useForm<FormData>({
-    mode: "onBlur"
+    mode: "onChange"
   });
   const nickname = getValues("nickname");
 

--- a/src/components/checkPassword/index.tsx
+++ b/src/components/checkPassword/index.tsx
@@ -63,6 +63,7 @@ const CheckPassword = ({ title, buttonText, to }: CheckPasswordProps) => {
       <UpperNavBar type="back" title={title} />
 
       <TextInput
+        type="password"
         variant="move"
         label="비밀번호"
         {...register("password", {
@@ -82,6 +83,7 @@ const CheckPassword = ({ title, buttonText, to }: CheckPasswordProps) => {
         />
       </S.NoticeContainer>
       <TextInput
+        type="password"
         variant="move"
         label="비밀번호 확인"
         {...register("secondPassword", {

--- a/src/pages/chat/ChatRoom.tsx
+++ b/src/pages/chat/ChatRoom.tsx
@@ -19,6 +19,7 @@ import useProductDetail from "@pages/productDetail/hooks/useProductDetail";
 import { useSearchParams } from "react-router-dom";
 import { formatDateTo } from "@utils/formatDateTo";
 import useIntersect from "@pages/products/hooks/useIntersect";
+import LoadingCircle from "@components/loading";
 
 const ChatRoom = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -97,7 +98,13 @@ const ChatRoom = () => {
     bottom.current!.scrollIntoView({ behavior: "smooth", block: "end" });
   };
 
-  const { data: messages, hasNextPage, isFetching, fetchNextPage } = useMessages({ code: roomId });
+  const {
+    data: messages,
+    hasNextPage,
+    isFetching,
+    fetchNextPage,
+    isLoading
+  } = useMessages({ code: roomId });
   const ref = useIntersect(async (entry, observer) => {
     observer.unobserve(entry.target);
     if (hasNextPage && !isFetching) {
@@ -108,6 +115,10 @@ const ChatRoom = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chatMessages]);
+
+  if (isLoading) {
+    return <LoadingCircle />;
+  }
 
   return (
     <>
@@ -152,7 +163,7 @@ const ChatRoom = () => {
       )}
       <S.ChatContainer ref={bottom} status={productData?.status}>
         {messages.length === 0 && chatMessages.length === 0 ? (
-          <p>메시지가 없습니다.</p>
+          ""
         ) : (
           <>
             {messages.length === 0 ? null : (

--- a/src/pages/login/EmailLogin.tsx
+++ b/src/pages/login/EmailLogin.tsx
@@ -67,6 +67,7 @@ const EmailLogin = () => {
             </div>
             <div>
               <TextInput
+                type="password"
                 variant="move"
                 label="비밀번호"
                 isSuccess={!errors.password}

--- a/src/pages/myPage/index.tsx
+++ b/src/pages/myPage/index.tsx
@@ -157,7 +157,7 @@ const MyPage = ({ width }: MyPageProps) => {
         >
           이용가이드
         </ListButton>
-        <ListButton width={width} icon={<TermIcon />} onClick={() => navigate("/terms")}>
+        <ListButton width={width} icon={<TermIcon />} onClick={() => navigate("/mypage/terms")}>
           이용약관
         </ListButton>
         <ListButton

--- a/src/pages/signIn/apis/compareNicknameApi.ts
+++ b/src/pages/signIn/apis/compareNicknameApi.ts
@@ -1,4 +1,5 @@
 import { authInstance } from "@apis/instance";
+import toast from "react-hot-toast";
 
 const compareNicknameApi = async (nickName: string): Promise<boolean> => {
   try {
@@ -7,6 +8,7 @@ const compareNicknameApi = async (nickName: string): Promise<boolean> => {
     return res.data.data.isDuplication;
   } catch (error) {
     console.error(error);
+    toast.error("닉네임 중복 확인에 실패했습니다.");
     return false;
   }
 };


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
214
## 작업 내용 (변경 사항)
- 로딩애니추가
- 닉네임 중복 조회 API 에러 해결 
(원인: nickname 값 인식 전 호출 / 해결: useForm 이벤트 수정)

## 스크린샷

## 테스트 결과

## 리뷰 요청 사항

close #214
